### PR TITLE
Change target branch of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
# Overview

Created a develop branch where dependabot PRs can be merged and tested before merging to main and triggering the deployment action.